### PR TITLE
Update download url

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
-$url = 'https://dl.bintray.com/mitchellh/packer/packer_0.8.6_windows_386.zip'
+$url = 'https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_windows_386.zip'
 $checksum = '36d485f8368212906560174eacff193be1c76893'
-$url64bit = 'https://dl.bintray.com/mitchellh/packer/packer_0.8.6_windows_amd64.zip'
+$url64bit = 'https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_windows_amd64.zip'
 $checksum64 = '05c19cc718dd84a9412d990dff309938130ec269'
 $legacyLocation = "$env:SystemDrive\HashiCorp\packer"
 $unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"


### PR DESCRIPTION
According to bintray's [packer page](https://bintray.com/mitchellh/packer), 

> Official packages have moved to the HashiCorp releases service: https://releases.hashicorp.com/. 