### PR TITLE
Introduce 32bit again

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ build_script:
   - ps: choco pack
 
 test_script:
-  - ps: .\test.ps1
+  - ps: .\test.ps1 -cpu x64
+  - ps: .\test.ps1 -cpu x86
 
 deploy_script:
   - ps: >-

--- a/test.ps1
+++ b/test.ps1
@@ -1,5 +1,15 @@
+param(
+  [string]$cpu
+)
 
-"Running tests"
+if (!$cpu) {
+  $cpu = "x64"
+}
+if ($cpu -eq "x86") {
+  $options = "-forcex86"
+}
+
+"Running tests for $cpu"
 $ErrorActionPreference = "Stop"
 
 if ($env:APPVEYOR_BUILD_VERSION) {

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
-$url = 'https://releases.hashicorp.com/packer/1.2.5/packer_1.2.5_windows_amd64.zip'
-$checksum = '537118113207f14f54352165ef664f53aa674a3b1e69ef653f917bab42f2c688'
+$url = 'https://releases.hashicorp.com/packer/1.2.5/packer_1.2.5_windows_386.zip'
+$checksum = 'a46e6ef42b0d5f7d30a8865be6bd26af3f7baeec70c4f48108c21e09e856222e'
 $checksumType = 'sha256'
 $url64 = 'https://releases.hashicorp.com/packer/1.2.5/packer_1.2.5_windows_amd64.zip'
 $checksum64 = '537118113207f14f54352165ef664f53aa674a3b1e69ef653f917bab42f2c688'

--- a/update.sh
+++ b/update.sh
@@ -21,14 +21,16 @@ esac
 version=$1
 
 shaurl="https://releases.hashicorp.com/packer/${version}/packer_${version}_SHA256SUMS"
+url="https://releases.hashicorp.com/packer/${version}/packer_${version}_windows_386.zip"
 url64="https://releases.hashicorp.com/packer/${version}/packer_${version}_windows_amd64.zip"
+checksum=$(curl "${shaurl}" | grep windows_386.zip | cut -f 1 -d " ")
 checksum64=$(curl "${shaurl}" | grep windows_amd64.zip | cut -f 1 -d " ")
 
 sed -i.bak "s/<version>.*<\/version>/<version>${version}<\/version>/" packer.nuspec
 
 sed -i.bak "s/version: .*{build}/version: ${version}.{build}/" appveyor.yml
 
-sed -i.bak "s!^\$url = '.*'!\$url = '${url64}'!" tools/chocolateyInstall.ps1
-sed -i.bak "s/^\$checksum = '.*'/\$checksum = '${checksum64}'/" tools/chocolateyInstall.ps1
+sed -i.bak "s!^\$url = '.*'!\$url = '${url}'!" tools/chocolateyInstall.ps1
+sed -i.bak "s/^\$checksum = '.*'/\$checksum = '${checksum}'/" tools/chocolateyInstall.ps1
 sed -i.bak "s!^\$url64 = '.*'!\$url64 = '${url64}'!" tools/chocolateyInstall.ps1
 sed -i.bak "s/^\$checksum64 = '.*'/\$checksum64 = '${checksum64}'/" tools/chocolateyInstall.ps1


### PR DESCRIPTION
Release 1.2.5 has the 32bit binaries again, so update the choco package to support 32bit and 64bit.
