### PR TITLE
Redeploy packer 1.3.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.3.3.{build}
+version: 1.3.3.20181213.{build}
 environment:
   TOKEN:
     secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66
@@ -14,7 +14,7 @@ deploy_script:
   - ps: >-
       Write-Host $env:APPVEYOR_REPO_TAG ;
       if($env:APPVEYOR_REPO_BRANCH -eq 'master' -And $env:APPVEYOR_REPO_TAG -eq 'true') {
-        $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$') ;
+        $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+\.[^.\\/]+$') ;
         choco apiKey -k $env:TOKEN -source https://push.chocolatey.org/ ;
         choco push packer.$version.nupkg
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ deploy_script:
   - ps: >-
       Write-Host $env:APPVEYOR_REPO_TAG ;
       if($env:APPVEYOR_REPO_BRANCH -eq 'master' -And $env:APPVEYOR_REPO_TAG -eq 'true') {
-        $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+\.[^.\\/]+$') ;
+        $version = $env:APPVEYOR_BUILD_VERSION -replace('\.[^.\\/]+$') ;
         choco apiKey -k $env:TOKEN -source https://push.chocolatey.org/ ;
         choco push packer.$version.nupkg
       }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm -v C:$(pwd):C:/code -w C:/code chocolateyfest/chocolatey choco pack

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm -it -v C:$(pwd):C:/code -w C:/code chocolateyfest/chocolatey powershell

--- a/packer.nuspec
+++ b/packer.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>packer</id>
-    <version>1.3.3</version>
+    <version>1.3.3.20181213</version>
     <title>Packer</title>
     <authors>Mitchell Hashimoto, Jack Pearkes, Mark Peek, Ross Smith II, Rickard von Essen</authors>
     <owners>Stefan Scherer</owners>

--- a/test.ps1
+++ b/test.ps1
@@ -20,11 +20,12 @@ if ($env:APPVEYOR_BUILD_VERSION) {
   [xml]$spec = Get-Content packer.nuspec
   $version = $spec.package.metadata.version
 }
+$binaryVersion = $version -replace('^([0-9]+\.[0-9]+\.[0-9]+)\..+$', '$1')
 
 "TEST: Version $version in packer.nuspec file should match"
 [xml]$spec = Get-Content packer.nuspec
 if ($spec.package.metadata.version.CompareTo($version)) {
-  Write-Error "FAIL: rong version in nuspec file!"
+  Write-Error "FAIL: Wrong version in nuspec file!"
 }
 
 "TEST: Package should contain only install script"
@@ -43,12 +44,12 @@ $zip.Dispose()
 "TEST: Version of binary should match"
 $v = $(packer version)
 $v
-if (-Not $v.Contains("Packer v$version")) {
+if (-Not $v.Contains("Packer v$binaryVersion")) {
   Write-Error "FAIL: Wrong version of packer installed!"
 }
 $v = $(packer --version)
 $v
-if (-Not $v.Contains("$version")) {
+if (-Not $v.Contains("$binaryVersion")) {
   Write-Error "FAIL: Wrong version of packer installed!"
 }
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm -v C:$(pwd):C:/code -w C:/code chocolateyfest/chocolatey choco install -y -pre -source . packer

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $url = 'https://releases.hashicorp.com/packer/1.3.3/packer_1.3.3_windows_386.zip'
-$checksum = '341ce78e59138324600336ada3576ec741a873abb3e2b489e52bc8dcd650a460'
+$checksum = '07ac92b10b6250edfe9280e777dc7752bf461c73eb9da7a14f34febd4ec3dc7a'
 $checksumType = 'sha256'
 $url64 = 'https://releases.hashicorp.com/packer/1.3.3/packer_1.3.3_windows_amd64.zip'
-$checksum64 = '493a88d0f0d3492d1ac3046edc22119490c211630510060fb611a2898f6d15d0'
+$checksum64 = '02e35d7ec6dbd009c117f9731c42b8ba67fd6d53ec05f57849445f316ae8f817'
 $checksumType64 = $checksumType
 $legacyLocation = "$env:SystemDrive\HashiCorp\packer"
 $unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"


### PR DESCRIPTION
Fix the tests to build a packer 1.3.3.20181213 choco package to fix the redeploy of the binaries by HashiCorp.

fixes #38 
