### PR TITLE
Packer 1.8.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.8.1.{build}
+version: 1.8.2.{build}
 environment:
   TOKEN:
     secure: KE3DuBSMhbBxLurkOXLrmAFbF+zptuCJztv1LDq1DfU65A1NSoYTI9JpYE63h/66

--- a/packer.nuspec
+++ b/packer.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>packer</id>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
     <title>Packer</title>
     <authors>Mitchell Hashimoto, Jack Pearkes, Mark Peek, Ross Smith II, Rickard von Essen</authors>
     <owners>Stefan Scherer</owners>

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
-$url = 'https://releases.hashicorp.com/packer/1.8.1/packer_1.8.1_windows_386.zip'
-$checksum = '43a1fa6955657eee20a9182faca56842e1ae71dc2f8cdcf5256cf462880c982d'
+$url = 'https://releases.hashicorp.com/packer/1.8.2/packer_1.8.2_windows_386.zip'
+$checksum = 'd13d2ecdcee4757b57ecb6baf9ba7e5d3c7550ea8cc43f0b737249c7f56bce2c'
 $checksumType = 'sha256'
-$url64 = 'https://releases.hashicorp.com/packer/1.8.1/packer_1.8.1_windows_amd64.zip'
-$checksum64 = '75b15c3b61cb9c7a0daa0a9f7746f7453beb30ab604da1826760fe693857801c'
+$url64 = 'https://releases.hashicorp.com/packer/1.8.2/packer_1.8.2_windows_amd64.zip'
+$checksum64 = '844cdde6f2e2dbe0d237668ca25bbe7697916bc2e036015b2c1fe54460dfc818'
 $checksumType64 = $checksumType
 $legacyLocation = "$env:SystemDrive\HashiCorp\packer"
 $unzipLocation = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"


### PR DESCRIPTION
https://github.com/hashicorp/packer/blob/v1.8.2/CHANGELOG.md
SECURITY:

- Bump packer-plugin-sdk to v0.3.0 to address reported vulnerabilities within the go-getter library. https://github.com/hashicorp/packer/pull/11843
- Bump plugins relying on go-getter for downloading remote files to address reported vulnerabilities within the go-getter library. See [HCSEC-2022-13](https://discuss.hashicorp.com/t/hcsec-2022-13-multiple- vulnerabilities-in-go-getter-library/39930) for details. https://github.com/hashicorp/packer/pull/11844