### PR TITLE
Fix CI: Add source to push action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Publish (noop)
         uses: crazy-max/ghaction-chocolatey@v2.1.0
         with:
-          args: push
+          args: push --source https://push.chocolatey.org/


### PR DESCRIPTION
With Chocolatey v2.0.0 we need to specify the source where to push the package.

See https://docs.chocolatey.org/en-us/guides/upgrading-to-chocolatey-v2-v6#removed-the-chocolatey-community-repository-as-the-default-push-source for details.
