### PR TITLE
fix: make AU workflow find nuspec

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -7,6 +7,12 @@ $ErrorActionPreference = 'Stop'
 
 Import-Module au -Force
 
+Set-Location -Path $PSScriptRoot
+
+if (-not (Test-Path (Join-Path $PSScriptRoot 'packer.nuspec'))) {
+  throw "packer.nuspec not found in $PSScriptRoot"
+}
+
 function global:au_GetLatest {
   $versionPattern = '^/packer/\d+\.\d+\.\d+/$'
 


### PR DESCRIPTION
Ensure update.ps1 always runs from the repository root so AU can discover packer.nuspec during the AU Update workflow.