### PR TITLE
fix: publish AU package from resolved nupkg path

### DIFF
--- a/.github/workflows/au.yml
+++ b/.github/workflows/au.yml
@@ -69,4 +69,7 @@ jobs:
       - name: Publish package
         if: steps.changes.outputs.changed == 'true'
         shell: pwsh
-        run: choco push .\packer.*.nupkg --source https://push.chocolatey.org/ --skip-duplicate
+        run: |
+          Get-ChildItem .\packer.*.nupkg | ForEach-Object {
+            choco push $_.FullName --source https://push.chocolatey.org/ --skip-duplicate
+          }


### PR DESCRIPTION
Use Get-ChildItem to resolve generated .nupkg files and push each package by full path. This avoids choco treating --skip-duplicate as part of the file argument when using a wildcard path.