### PR TITLE
fix: correct argument order for choco push

### DIFF
--- a/.github/workflows/au.yml
+++ b/.github/workflows/au.yml
@@ -71,5 +71,5 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem .\packer.*.nupkg | ForEach-Object {
-            choco push $_.FullName --source https://push.chocolatey.org/ --skip-duplicate
+            choco push --source https://push.chocolatey.org/ --skip-duplicate $_.FullName
           }


### PR DESCRIPTION
Place --source and --skip-duplicate before the .nupkg path so Chocolatey does not treat flags as part of the file argument during AU publish.