### PR TITLE
fix: harden AU chocolatey publish step

### DIFF
--- a/.github/workflows/au.yml
+++ b/.github/workflows/au.yml
@@ -70,6 +70,21 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         shell: pwsh
         run: |
-          Get-ChildItem .\packer.*.nupkg | ForEach-Object {
-            choco push --source https://push.chocolatey.org/ --skip-duplicate $_.FullName
+          $packages = Get-ChildItem .\packer.*.nupkg
+          if (-not $packages) {
+            throw "No package artifact found to publish."
+          }
+
+          foreach ($package in $packages) {
+            $pushOutput = choco push $package.FullName --source https://push.chocolatey.org/ 2>&1 | Out-String
+            $pushOutput | Write-Host
+
+            if ($LASTEXITCODE -ne 0) {
+              if ($pushOutput -match '(already exists|409|conflict)') {
+                Write-Host "Package already exists on Chocolatey. Skipping: $($package.Name)"
+                continue
+              }
+
+              throw "Chocolatey push failed for $($package.Name)"
+            }
           }


### PR DESCRIPTION
Use valid choco push invocation and explicit error handling in AU workflow.\n\n- push each resolved .nupkg file with choco push <path> --source ...\n- fail fast when no artifact exists\n- treat duplicate publish responses (already exists / 409 conflict) as non-fatal to keep reruns idempotent\n- fail on all other publish errors